### PR TITLE
Remove duplicate redirects in default ini

### DIFF
--- a/DMRGateway.ini
+++ b/DMRGateway.ini
@@ -26,8 +26,8 @@ Port=62030
 # Local=3351
 # Options=
 Slot=1
-TG=8
-Base=84000
+TG=6
+Base=64000
 Password=passw0rd
 Debug=0
 


### PR DESCRIPTION


XLX Network 1 is now on TG6 with commands base 64000
XLX Network 2 remains on TG7 with commands base 74000
DMR Network 1 remains on TG9
DMR Network 2 remains on TG8